### PR TITLE
Utilisation de DsfrBaseForm pour les formulaires d'exemple

### DIFF
--- a/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
+++ b/dsfr/templates/dsfr/form_field_snippets/input_snippet.html
@@ -8,10 +8,10 @@
 
     {% if field.errors %}
       {% with aria_describedby="aria-describedby:"|add:field.auto_id|add:"-desc-error" %}
-        {{ field|add_class:'fr-input'|attr:"aria-invalid:true"|attr:aria_describedby }}
+        {{ field|attr:"aria-invalid:true"|attr:aria_describedby }}
       {% endwith %}
     {% else %}
-      {{ field|add_class:'fr-input' }}
+      {{ field }}
     {% endif %}
 
     {% if field.errors %}

--- a/example_app/forms.py
+++ b/example_app/forms.py
@@ -131,7 +131,7 @@ class ExampleForm(DsfrBaseForm):
         self.set_autofocus_on_first_error()
 
 
-class AuthorCreateForm(ModelForm):
+class AuthorCreateForm(ModelForm, DsfrBaseForm):
     class Meta:
         model = Author
         exclude = []
@@ -153,7 +153,7 @@ BOOK_FORMAT = (
 )
 
 
-class BookCreateForm(ModelForm):
+class BookCreateForm(ModelForm, DsfrBaseForm):
     class Meta:
         model = Book
         exclude = []

--- a/example_app/urls.py
+++ b/example_app/urls.py
@@ -33,6 +33,6 @@ urlpatterns = [
         "form_formset/",
         AuthorCreateView.as_view(),
         name="form_formset",
-        distill_file="django-dsfr/example_form.html",
+        distill_file="django-dsfr/formsets/index.html",
     ),
 ]


### PR DESCRIPTION
Ajouter la classe fr-input directement avec widget_tweaks pose des effets de bord parce que cela dépend en fait du type de champ.

Gestion des formulaires d'exemple avec  DsfrBaseForm à la place